### PR TITLE
[fix] feat #14 共有レシピの編集ができない問題を解決

### DIFF
--- a/recipes/views.py
+++ b/recipes/views.py
@@ -256,7 +256,7 @@ def delete_shared_recipe(request, token):
 @login_required
 def shared_recipe_edit(request, token):
     shared_recipe = get_object_or_404(SharedRecipe, access_token=token, created_by=request.user)
-    steps = SharedRecipeStep.objects.filter(shared_recipe=shared_recipe).order_by('step_number')
+    steps = SharedRecipeStep.objects.filter(recipe=shared_recipe).order_by('step_number')
 
     if request.method == 'POST':
         # Form層でバリデーション
@@ -277,7 +277,7 @@ def shared_recipe_edit(request, token):
             return redirect('recipes:mypage')
         else:
             # フォームエラーの場合は再表示
-            steps = SharedRecipeStep.objects.filter(shared_recipe=shared_recipe).order_by('step_number')
+            steps = SharedRecipeStep.objects.filter(recipe=shared_recipe).order_by('step_number')
 
     return render(request, 'recipes/shared_recipe_edit.html', {
         'shared_recipe': shared_recipe,


### PR DESCRIPTION
[fix] feat #14 共有レシピの編集ができない問題を解決

マイページの「編集」ボタンを押して共有レシピ編集画面に飛ぶと500エラーが出る問題を解消した。
原因は、スクリプト内で期待しているDBのカラム名(shared_recipe)と、実際のカラム名(recipe)に齟齬があったことだった。
DBカラム名の方に合わせて修正

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix shared recipe editing by filtering steps with `recipe` instead of `shared_recipe` to prevent errors.
> 
> - **Views**:
>   - `recipes/views.py` → `shared_recipe_edit`:
>     - Fetch steps via `SharedRecipeStep.objects.filter(recipe=shared_recipe)` instead of `...filter(shared_recipe=shared_recipe)`.
>     - Apply the same fix in the form-error re-render path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abbd29cfaf3d0f7e55bd6a7aa9cd30294e56d3a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->