### PR TITLE
[update] feat #16 DBをAurora Serverless v2に移行

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 asgiref==3.10.0
 autopep8==2.3.2
 beautifulsoup4==4.14.2
+boto3==1.40.74
+botocore==1.40.74
 bs4==0.0.2
 certifi==2025.11.12
 cffi==2.0.0
@@ -12,6 +14,7 @@ django-environ==0.12.0
 django-extensions==4.1
 django-recaptcha==4.1.0
 idna==3.11
+jmespath==1.0.1
 MarkupSafe==3.0.3
 mysqlclient==2.2.7
 packaging==25.0
@@ -20,7 +23,10 @@ pip-review==1.3.0
 pycodestyle==2.14.0
 pycparser==2.23
 pyOpenSSL==25.3.0
+python-dateutil==2.9.0.post0
 requests==2.32.5
+s3transfer==0.14.0
+six==1.17.0
 soupsieve==2.8
 sqlparse==0.5.3
 stripe==13.2.0


### PR DESCRIPTION
DBをAurora Serverless v2に移行。
開発環境では本番環境DBに触らないようにしている

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches database to Aurora Serverless v2 using AWS Secrets Manager for credentials, adds required AWS SDK deps, and introduces dev-only DB env variables to avoid touching prod.
> 
> - **Backend/Settings (`Co_fitting/settings.py`)**:
>   - Add `boto3`/`botocore` integration and `get_aurora_secret` to fetch credentials from AWS Secrets Manager (`AURORA_SECRET_ARN`).
>   - Update `DATABASES['default']` to use env `DB_NAME`, `DB_HOST`, `DB_PORT` and secret `username`/`password` for MySQL (Aurora).
>   - Add DEBUG-guarded dev DB env variables to prevent accessing prod in development.
> - **Dependencies (`requirements.txt`)**:
>   - Add AWS SDK packages: `boto3`, `botocore`, `jmespath`, `s3transfer`, `python-dateutil`, `six`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abca9a966b91ccc2aa61d5226654bcf1612d3bd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->