### PR TITLE
[update] feat #20 共有レシピ受け取り時のメモ欄を削除

### DIFF
--- a/recipes/static/script/index.js
+++ b/recipes/static/script/index.js
@@ -592,7 +592,6 @@ $(document).ready(function() {
                 <p><strong>総湯量:</strong> <span>${recipeData.water_ml}ml</span></p>
                 ${recipeData.is_ice ? `<p><strong>氷量:</strong> <span>${recipeData.ice_g}g</span></p>` : ''}
                 <p><strong>ステップ数:</strong> <span>${recipeData.len_steps}ステップ</span></p>
-                ${recipeData.memo ? `<p><strong>メモ:</strong> <span>${recipeData.memo}</span></p>` : ''}
             </div>
             <div class="modal-actions">
                 <button id="add-to-preset-btn" class="btn btn-primary">追加</button>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Remove the memo display from the shared recipe modal when receiving a shared recipe.
> 
> - **Frontend**
>   - **Shared recipe modal (`recipes/static/script/index.js`)**: Remove rendering of `memo` field in `showSharedRecipeModal()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89bb769371f68ea75914002fe4556f38ac919a9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->