### PR TITLE
[fix] feat #32 共有レシピ受け取りができない問題を修正

### DIFF
--- a/Co_fitting/urls.py
+++ b/Co_fitting/urls.py
@@ -23,6 +23,7 @@ from django.conf.urls.static import static
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', recipe_views.index, name='home'),           # トップページ（変換）
+    path('index/', recipe_views.index, name='home'),
     path('mypage/', recipe_views.mypage, name='mypage'), # マイページ
     path('recipes/', include('recipes.urls')),           # その他レシピ関連
     path('articles/', include('articles.urls')),


### PR DESCRIPTION
先のリファクタリングの際、/indexにアクセスした際のルーティング定義を消してしまっていた。これを復活させて、問題なく共有レシピ受け取りができることを確認