### PR TITLE
[fix change] feat #45 非ログイン時の「プレミアム限定機能」モーダルからは、ログインページへ遷移させるように変更

### DIFF
--- a/Co_fitting/static/script/common.js
+++ b/Co_fitting/static/script/common.js
@@ -205,7 +205,7 @@ const ModalWindow = {
             <p>${featureName}はプレミアムプラン以上で利用できる機能です。</p>
             <p>サインアップ・ログインののち、プレミアムプランにアップグレードして、さらに便利な機能をお楽しみください。</p>
             <div class="modal-actions">
-                <button id="view-plans-btn" class="btn btn-primary">プランを確認</button>
+                <button id="view-plans-btn" class="btn btn-primary">ログイン</button>
                 <button type="button" class="btn btn-secondary" data-modal-close>閉じる</button>
             </div>
         `;

--- a/purchase/urls.py
+++ b/purchase/urls.py
@@ -3,6 +3,7 @@ from . import views
 
 app_name = 'purchase'
 urlpatterns = [
+    path('', views.select_plan, name='index'),
     path('create_checkout_session/', views.create_checkout_session, name='create_checkout_session'),
     path('already_subscribed/', views.already_subscribed, name='already_subscribed'),
     path('checkout_success/', views.checkout_success, name='checkout_success'),


### PR DESCRIPTION
これまでは「プランを確認」ページに誘導しており、Notfoundが出ていた。
そもそも非ログインユーザーに対してはまずログイン・サインアップを促す方が正しいので、そのように仕様を変更した